### PR TITLE
retiradas as chamadas da função destroyConnection

### DIFF
--- a/src/controller/CollectionController.ts
+++ b/src/controller/CollectionController.ts
@@ -35,7 +35,6 @@ export class CollectionController {
         message: e.message,
       });
     }
-    await BaseDatabase.destroyConnection();
   };
 
   public getAllCollections = async (req: Request, res: Response) => {
@@ -62,7 +61,6 @@ export class CollectionController {
         message: e.message,
       });
     }
-    await BaseDatabase.destroyConnection();
   };
 
   async createCollection(req: Request, res: Response) {
@@ -84,7 +82,5 @@ export class CollectionController {
     } catch (error) {
       res.status(400).send({ error: error.message });
     }
-
-    await BaseDatabase.destroyConnection();
   }
 }

--- a/src/controller/CollectionsImagesController.ts
+++ b/src/controller/CollectionsImagesController.ts
@@ -23,7 +23,6 @@ export class CollectionsImagesController {
         message: e.message,
       });
     }
-    await BaseDatabase.destroyConnection();
   };
 
   async addImage(req: Request, res: Response) {
@@ -44,7 +43,5 @@ export class CollectionsImagesController {
     } catch (error) {
       res.status(400).send({ error: error.message });
     }
-
-    await BaseDatabase.destroyConnection();
   }
 }

--- a/src/controller/ImageController.ts
+++ b/src/controller/ImageController.ts
@@ -22,7 +22,6 @@ export class ImageController {
         message: e.message,
       });
     }
-    await BaseDatabase.destroyConnection();
   };
 
   public getImage = async (req: Request, res: Response) => {
@@ -50,7 +49,6 @@ export class ImageController {
         message: e.message,
       });
     }
-    await BaseDatabase.destroyConnection();
   };
 
   async createImage(req: Request, res: Response) {
@@ -73,7 +71,5 @@ export class ImageController {
     } catch (error) {
       res.status(400).send({ error: error.message });
     }
-
-    await BaseDatabase.destroyConnection();
   }
 }

--- a/src/controller/UserController.ts
+++ b/src/controller/UserController.ts
@@ -30,8 +30,6 @@ export class UserController {
     } catch (error) {
       res.status(400).send({ error: error.message });
     }
-
-    await BaseDatabase.destroyConnection();
   }
 
   async login(req: Request, res: Response) {
@@ -49,7 +47,5 @@ export class UserController {
     } catch (error) {
       res.status(400).send({ error: error.message });
     }
-
-    await BaseDatabase.destroyConnection();
   }
 }


### PR DESCRIPTION
A função destroyConnection estava causando um bug em que uma requisição não era feita por estar aguardando a destroyConnection de uma requisição anterior